### PR TITLE
Make it similar to rebar3_ex_doc

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -75,4 +75,4 @@
     {prefix_ref_vsn_with_v, false}
 ]}.
 
-{hex, [{doc, ex_doc}]}.
+{hex, [{doc, #{provider => ex_doc}}]}.


### PR DESCRIPTION
# Description

I don't understand how this is working at the moment, but maybe:

1. either some defaults are applied
2. this isn't required
3. this is being coerced into something else

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/rebar3_checkshell/blob/main/CONTRIBUTING.md)
