### PR TITLE
Fix as per rebar3 constraints

### DIFF
--- a/.github/workflows/rebar3_depup.sh
+++ b/.github/workflows/rebar3_depup.sh
@@ -16,7 +16,9 @@ fi
 git checkout -b "${BRANCH}"
 mkdir -p "${HOME}/.config/rebar3"
 echo "{plugins, [rebar3_depup]}." >"${HOME}/.config/rebar3/rebar.config"
-rebar3 up
+rebar3 update-deps --replace
+rebar3 upgrade --all
+rebar3 fmt
 
 if ! git diff --exit-code >/dev/null; then
     # there's stuff to push

--- a/rebar.config
+++ b/rebar.config
@@ -18,10 +18,7 @@
 
 {deps, [{tls_certificate_check, "1.20.0"}]}.
 
-{alias, [
-    {ci, [fmt, hank, lint, xref, dialyzer, ct, cover, ex_doc]},
-    {up, [{'update-deps', "--replace"}, {upgrade, "--all"}, fmt]}
-]}.
+{alias, [{ci, [fmt, hank, lint, xref, dialyzer, ct, cover, ex_doc]}]}.
 
 {shell, [{apps, [rebar3_checkshell]}]}.
 


### PR DESCRIPTION
# Description

`upgrade` and `fmt` aren't taken into account in the same "session" as `update-deps`, in the `up` alias.

Instead of digging deeper in `rebar3` (and potentially discussing if this is fixable or required) I go with what works, for the time being...

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/rebar3_checkshell/blob/main/CONTRIBUTING.md)
