### PR TITLE
Tweak CI versions: move the world forward

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,5 +4,4 @@ A brief description of your changes.
 
 Closes #&lt;issue&gt;.
 
-- [ ] I have performed a self-review of my changes
 - [ ] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/rebar3_checkshell/blob/main/CONTRIBUTING.md)

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -53,6 +53,7 @@ jobs:
 
       - run: |
           # there be dragons
+          brew update
           erlang=$(< .tool-versions grep erlang | sed -E 's/erlang ([^\.]+).*/\1/g')
           brew install "erlang@${erlang}"
         if: ${{matrix.os-base == 'macos'}}

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -74,8 +74,11 @@ jobs:
         if: ${{matrix.os-base != 'macos'}}
 
       - run: |
-          brew install erlang@${{matrix.otp-version}}
-          brew install rebar3
+          # there be dragons
+          sed -i '' 's/erlang .*/erlang ${{matrix.otp-version}}/g' .tool-versions
+        if: ${{matrix.os-base == 'macos'}}
+
+      - uses: asdf-vm/actions/install@v3.0.2
         if: ${{matrix.os-base == 'macos'}}
 
       - name: Restore _build

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -56,6 +56,7 @@ jobs:
           brew update
           erlang=$(< .tool-versions grep erlang | sed -E 's/erlang ([^\.]+).*/\1/g')
           brew install "erlang@${erlang}"
+          brew install rebar3
         if: ${{matrix.os-base == 'macos'}}
 
       - name: Restore _build

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -44,7 +44,8 @@ jobs:
             rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
           - os-base: windows
             os-vsn: ${{ needs.vsns.outputs.windows }}
-            otp-version: 26
+            # 26.2.5.2 failing for some reason...
+            otp-version: 26.2.5.1
             rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
           - os-base: windows
             os-vsn: ${{ needs.vsns.outputs.windows }}

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -20,8 +20,6 @@ jobs:
       windows: 2022
       # renovate datasource: github-runners, depName: macos
       macos: 14
-      # renovate datasource: github-tags, depName: erlang/rebar3
-      rebar3: 3.24.0
 
     steps:
       - run: echo "versions set!"
@@ -36,30 +34,10 @@ jobs:
         include:
           - os-base: ubuntu
             os-vsn: ${{ needs.vsns.outputs.ubuntu }}
-            otp-version: 26
-            rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
-          - os-base: ubuntu
-            os-vsn: ${{ needs.vsns.outputs.ubuntu }}
-            otp-version: 27
-            rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
           - os-base: windows
             os-vsn: ${{ needs.vsns.outputs.windows }}
-            # 26.2.5.2 failing for some reason...
-            otp-version: 26.2.5.1
-            rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
-          - os-base: windows
-            os-vsn: ${{ needs.vsns.outputs.windows }}
-            otp-version: 27
-            rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
-          # macos, for now, is considered best-effort
-          - os-base: macos
-            os-vsn: ${{ needs.vsns.outputs.macos }}
-            otp-version: 26
-            rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
           - os-base: macos  # macos, for now, is considered best-effort
             os-vsn: ${{ needs.vsns.outputs.macos }}
-            otp-version: 27
-            rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
 
     runs-on: ${{matrix.os-base}}-${{matrix.os-vsn}}
 
@@ -69,16 +47,14 @@ jobs:
       - uses: erlef/setup-beam@b9c58b0450cd832ccdb3c17cc156a47065d2114f # v1.18.1
         id: setup-beam
         with:
-          otp-version: ${{matrix.otp-version}}
-          rebar3-version: ${{matrix.rebar3-version}}
+          version-type: strict
+          version-file: .tool-versions
         if: ${{matrix.os-base != 'macos'}}
 
       - run: |
           # there be dragons
-          sed -i '' 's/erlang .*/erlang ${{matrix.otp-version}}/g' .tool-versions
-        if: ${{matrix.os-base == 'macos'}}
-
-      - uses: asdf-vm/actions/install@v3.0.2
+          erlang=$(< .tool-versions grep erlang | sed -E 's/erlang ([^\.]+).*/\1/g')
+          brew install "erlang@${erlang}"
         if: ${{matrix.os-base == 'macos'}}
 
       - name: Restore _build

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -36,28 +36,28 @@ jobs:
         include:
           - os-base: ubuntu
             os-vsn: ${{ needs.vsns.outputs.ubuntu }}
-            otp-version: 25
+            otp-version: 26
             rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
           - os-base: ubuntu
             os-vsn: ${{ needs.vsns.outputs.ubuntu }}
-            otp-version: 26
-            rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
-          - os-base: windows
-            os-vsn: ${{ needs.vsns.outputs.windows }}
-            otp-version: 25
+            otp-version: 27
             rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
           - os-base: windows
             os-vsn: ${{ needs.vsns.outputs.windows }}
             otp-version: 26
+            rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
+          - os-base: windows
+            os-vsn: ${{ needs.vsns.outputs.windows }}
+            otp-version: 27
             rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
           # macos, for now, is considered best-effort
           - os-base: macos
             os-vsn: ${{ needs.vsns.outputs.macos }}
-            otp-version: 25
+            otp-version: 26
             rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
           - os-base: macos  # macos, for now, is considered best-effort
             os-vsn: ${{ needs.vsns.outputs.macos }}
-            otp-version: 26
+            otp-version: 27
             rebar3-version: ${{ needs.vsns.outputs.rebar3 }}
 
     runs-on: ${{matrix.os-base}}-${{matrix.os-vsn}}


### PR DESCRIPTION
# Description

A bit of version bumping.

⚠️ I guess this one has to wait for `erlang@27` to be Homebrew-released.

I tried with `asdf` and not only does it take long, but it fails in the end.
I didn't try with a. `kerl` directly, b. a Docker container image (didn't even search for one), ...

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/rebar3_checkshell/blob/main/CONTRIBUTING.md)
