### PR TITLE
Move support range to OTP 28+

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{minimum_otp_vsn, "25"}.
+{minimum_otp_vsn, "28"}.
 
 {erl_opts, [
     debug_info,


### PR DESCRIPTION
# Description

We move to OTP 28+.

Most recent versions are 25+ -compatible, and we can go back if there's interested, but for now this is what we chose.

- [x] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/rebar3_checkshell/blob/main/CONTRIBUTING.md)
